### PR TITLE
BS-28-Get-all-party-members

### DIFF
--- a/server/src/controllers/UserGroup.ts
+++ b/server/src/controllers/UserGroup.ts
@@ -97,10 +97,10 @@ const inviteUser = async (req: Request, res: Response): Promise<Response> => {
         }
         else {
             res.status(400);
-            if(!user){
-                return res.json({ error: "No such user exisit" }) ;
+            if (!user) {
+                return res.json({ error: "No such user exisit" });
             };
-            return res.json({ error: "No such group exisit" }) ;
+            return res.json({ error: "No such group exisit" });
         };
     }
     catch (error: any) {
@@ -110,7 +110,59 @@ const inviteUser = async (req: Request, res: Response): Promise<Response> => {
 
 };
 
+const getMembers = async (req: Request, res: Response): Promise<Response> => {
+    const groupId: string = req.params.groupId;
+
+    if (!groupId) {
+        res.status(400);
+        return res.json({ error: "Failed to find group" });
+    };
+
+    try {
+        //Check if group exist in the table 
+        const group: any = await UserGroup.findOne({
+            where: {
+                groupId: groupId
+            }
+        });
+
+        if (!group) {
+            res.status(400);
+            return res.json({ error: "No such group exisit" });
+        };
+
+        const party: any = await UserGroup.findAll({
+            where: {
+                groupId: parseInt(groupId)
+            },
+            // Attributes wanted
+            attributes: ['id', 'role', 'userId', 'groupId']
+        });
+
+        const members: Array<Array<any>> = [];
+
+        for (let i = 0; i < party.length; i++) {
+            const userId: number = party[i].dataValues.userId;
+            const user: any = await User.findOne({
+                where: {
+                    id: userId
+                }
+            });
+            members.push([user.username, party[i].dataValues.role, user.id]);
+        };
+
+        res.status(200);
+        return res.json({ members });
+    }
+    catch (error: any) {
+        res.status(500);
+        return res.json({ error: `Unexpected error occured with error: ${error}` });
+    };
+};
+
+
 export {
     createUserGroup,
-    inviteUser
+    inviteUser,
+    getMembers
 };

--- a/server/src/controllers/UserGroup.ts
+++ b/server/src/controllers/UserGroup.ts
@@ -115,7 +115,7 @@ const getMembers = async (req: Request, res: Response): Promise<Response> => {
 
     if (!groupId) {
         res.status(400);
-        return res.json({ error: "Failed to find group" });
+        return res.json({ error: "No groupId provided" });
     };
 
     try {
@@ -128,7 +128,7 @@ const getMembers = async (req: Request, res: Response): Promise<Response> => {
 
         if (!group) {
             res.status(400);
-            return res.json({ error: "No such group exisit" });
+            return res.json({ error: "No such group exist" });
         };
 
         const party: any = await UserGroup.findAll({

--- a/server/src/routes/UserGroup.ts
+++ b/server/src/routes/UserGroup.ts
@@ -1,9 +1,10 @@
 import express from "express";
-import { createUserGroup, inviteUser } from "../controllers/UserGroup";
+import { createUserGroup, inviteUser, getMembers } from "../controllers/UserGroup";
 
 const router: express.Router = express.Router();
 
 router.post('/create', createUserGroup);
 router.post('/invite', inviteUser);
+router.get('/members/:groupId', getMembers)
 
 export default router;

--- a/server/src/test/usergroup.test.ts
+++ b/server/src/test/usergroup.test.ts
@@ -1,7 +1,7 @@
 import UserGroup from "../models/UserGroup";
 import User from "../models/Users";
 import Group from "../models/Group";
-import { inviteUser, createUserGroup } from "../controllers/UserGroup";
+import { inviteUser, createUserGroup, getMembers } from "../controllers/UserGroup";
 
 // Mock Group.create and findOne
 jest.mock('../models/Group', (): any => ({
@@ -12,7 +12,8 @@ jest.mock('../models/Group', (): any => ({
 // Mock UserGroup.create and findOne
 jest.mock('../models/UserGroup', (): any => ({
     create: jest.fn(),
-    findOne: jest.fn() //to mock the findOne function
+    findOne: jest.fn(), //to mock the findOne function
+    findAll: jest.fn() //to mock the findAll function
 }));
 
 // Mock User.findOne
@@ -247,4 +248,38 @@ describe('On vaild user_group invitation input', (): void => {
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith({ success: "Successfully added to group" });
     });
+});
+
+/*UserGroup get all party members test*/
+describe('On invaild get all party members input', (): void => {
+    beforeEach((): void => {
+        jest.clearAllMocks(); // Reset mocks before each test case to not corrupt results
+    });
+
+    it('should return a status code of 400 and error if groupId is missing from params', async (): Promise<void> => {
+        const req: any = {
+            params: {
+                groupId: null
+            }
+        };
+
+        await getMembers(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "No groupId provided" });
+    });
+
+    it('should return a status code of 400 and error if group doesnt exist', async (): Promise<void> => {
+        const req: any = {
+            params: {
+                groupId: Number.MAX_SAFE_INTEGER
+            }
+        };
+
+        (UserGroup as any).findOne.mockResolvedValueOnce(false);
+
+        await getMembers(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "No such group exist" });
+    });
+
 });

--- a/server/src/test/usergroup.test.ts
+++ b/server/src/test/usergroup.test.ts
@@ -283,3 +283,48 @@ describe('On invaild get all party members input', (): void => {
     });
 
 });
+
+describe('On vaild get all party members input', (): void => {
+    beforeEach((): void => {
+        jest.clearAllMocks(); // Reset mocks before each test case to not corrupt results
+    });
+
+    it('should return a status code of 200 and list of all users in the group', async (): Promise<void> => {
+        const req: any = {
+            params: {
+                groupId: Number.MAX_SAFE_INTEGER
+            }
+        };
+
+        (UserGroup as any).findOne.mockResolvedValueOnce(true);
+        (UserGroup as any).findAll.mockResolvedValueOnce([
+            {
+                dataValues: {
+                    id: Number.MIN_VALUE,
+                    role: 'Owner',
+                    userId: Number.MIN_VALUE,
+                    groupId: Number.MAX_SAFE_INTEGER
+                }
+            }
+        ]);
+
+        (User as any).findOne.mockResolvedValueOnce({
+            id: Number.MIN_VALUE,
+            username: 'Deondrae',
+            password: 'HashedPassword',
+            email: 'dev@deving.com'
+        });
+
+        await getMembers(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({
+            "members": [
+                [
+                    "Deondrae",
+                    "Owner",
+                    Number.MIN_VALUE
+                ]
+            ]
+        });
+    });
+});


### PR DESCRIPTION
Established a get all member feature
- Queries the UserGroup table and returns needed attributes being ['id', 'role', 'userId', 'groupId']
- Finds all the users from the UserGroup querie
- Return a object of arrays of arrays containing each group member role, id, and name 