### PR TITLE
BS-40-Yelp-pubs-location-fetch

### DIFF
--- a/server/src/controllers/Yelp.ts
+++ b/server/src/controllers/Yelp.ts
@@ -6,7 +6,8 @@ const getPubs = async (req: Request, res: Response): Promise<void> => {
     const lat: string = req.params.lat;
     const lon: string = req.params.lon;
 
-    const missingField: string = lat ? '' : 'lat' || lon ? '' : 'lon';
+    const missingField: string = !lat ? 'lat' : '' || !lon ? 'lon' : '';
+    
     if (missingField) {
         res.status(400).json({ error: `Failed to fetch bars missing ${missingField}` });
         return;

--- a/server/src/controllers/Yelp.ts
+++ b/server/src/controllers/Yelp.ts
@@ -26,9 +26,8 @@ const getPubs = async (req: Request, res: Response): Promise<void> => {
             res.status(401).json({ error: 'Failed to fetch data from Yelp API' });
             return;
         }
-
         const data = await response.json();
-        res.json({businesses: data.businesses});
+        res.status(200).json({businesses: data.businesses});
         return
     } catch (error: any) {
         res.status(500).json({ error: `Failed to fetch pubs with unexpected error: ${error}` });

--- a/server/src/controllers/Yelp.ts
+++ b/server/src/controllers/Yelp.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from "express";
+import 'dotenv/config'
+
+const getPubs = async (req: Request, res: Response): Promise<void> => {
+    /*Have to format res.status.json to avoid header error*/
+    const lat: string = req.params.lat;
+    const lon: string = req.params.lon;
+
+    const missingField: string = lat ? '' : 'lat' || lon ? '' : 'lon';
+    if (missingField) {
+        res.status(400).json({ error: `Failed to fetch bars missing ${missingField}` });
+        return;
+    }
+
+    try {
+        const url: string = `https://api.yelp.com/v3/businesses/search?term=Pubs&latitude=${lat}&longitude=${lon}`;
+        const response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${process.env.YELP_API_TOKEN}`,
+                'Content-Type': 'application/json',
+            }
+        });
+
+        if (!response.ok) {
+            res.status(401).json({ error: 'Failed to fetch data from Yelp API' });
+            return;
+        }
+
+        const data = await response.json();
+        res.json({businesses: data.businesses});
+        return
+    } catch (error: any) {
+        res.status(500).json({ error: `Failed to fetch pubs with unexpected error: ${error}` });
+    };
+};
+
+export {
+    getPubs
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import groupRouter from "./routes/Group";
 import favoriteRouter from "./routes/Favorites";
 import userGroupRouter from "./routes/UserGroup";
 import visitedRouter from "./routes/Visited";
+import yelpRouter from "./routes/YelpFetch"
 
 import "dotenv/config";
 
@@ -34,6 +35,7 @@ app.use("/group", groupRouter);
 app.use("/visit", visitedRouter);
 app.use("/favorite", favoriteRouter);
 app.use("/party", userGroupRouter);
+app.use("/yelp", yelpRouter);
 
 sequelize
   .sync()

--- a/server/src/routes/YelpFetch.ts
+++ b/server/src/routes/YelpFetch.ts
@@ -1,0 +1,8 @@
+import express from "express";
+import { getPubs } from "../controllers/Yelp";
+
+const router: express.Router = express.Router();
+
+router.get('/pubs/:lat/:lon', getPubs);
+
+export default router;

--- a/server/src/test/yelp.test.ts
+++ b/server/src/test/yelp.test.ts
@@ -1,65 +1,65 @@
 import { getPubs } from "../controllers/Yelp";
 
+const sampleYelpData: any = {
+    "businesses": [
+        {
+            "id": "FmGF1B-Rpsjq1f5b56qMwg",
+            "alias": "molinari-delicatessen-san-francisco",
+            "name": "Molinari Delicatessen",
+            "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/CwWUZKM8T3QaSvvEMjI7pw/o.jpg",
+            "is_closed": false,
+            "url": "https://www.yelp.com/biz/molinari-delicatessen-san-francisco?adjust_creative=KmEoncUp5OnRvU5oNHoPyQ&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=KmEoncUp5OnRvU5oNHoPyQ",
+            "review_count": 1379,
+            "categories": [
+                {
+                    "alias": "gourmet",
+                    "title": "Specialty Food"
+                },
+                {
+                    "alias": "delis",
+                    "title": "Delis"
+                }
+            ],
+            "rating": 4.4,
+            "coordinates": {
+                "latitude": 37.79838,
+                "longitude": -122.40782
+            },
+            "transactions": [
+                "delivery",
+                "pickup"
+            ],
+            "price": "$$",
+            "location": {
+                "address1": "373 Columbus Ave",
+                "address2": "",
+                "address3": "",
+                "city": "San Francisco",
+                "zip_code": "94133",
+                "country": "US",
+                "state": "CA",
+                "display_address": [
+                    "373 Columbus Ave",
+                    "San Francisco, CA 94133"
+                ]
+            },
+            "phone": "+14154212337",
+            "display_phone": "(415) 421-2337",
+            "distance": 1465.2460213942109
+        },
+    ],
+    "total": 1,
+    "region": {
+        "center": {
+            "longitude": -122.399972,
+            "latitude": 37.786882
+        }
+    }
+}
 /* Mock fetch function */
 global.fetch = jest.fn(() =>
     Promise.resolve({
-        json: () => Promise.resolve({
-            "businesses": [
-                {
-                    "id": "FmGF1B-Rpsjq1f5b56qMwg",
-                    "alias": "molinari-delicatessen-san-francisco",
-                    "name": "Molinari Delicatessen",
-                    "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/CwWUZKM8T3QaSvvEMjI7pw/o.jpg",
-                    "is_closed": false,
-                    "url": "https://www.yelp.com/biz/molinari-delicatessen-san-francisco?adjust_creative=KmEoncUp5OnRvU5oNHoPyQ&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=KmEoncUp5OnRvU5oNHoPyQ",
-                    "review_count": 1379,
-                    "categories": [
-                        {
-                            "alias": "gourmet",
-                            "title": "Specialty Food"
-                        },
-                        {
-                            "alias": "delis",
-                            "title": "Delis"
-                        }
-                    ],
-                    "rating": 4.4,
-                    "coordinates": {
-                        "latitude": 37.79838,
-                        "longitude": -122.40782
-                    },
-                    "transactions": [
-                        "delivery",
-                        "pickup"
-                    ],
-                    "price": "$$",
-                    "location": {
-                        "address1": "373 Columbus Ave",
-                        "address2": "",
-                        "address3": "",
-                        "city": "San Francisco",
-                        "zip_code": "94133",
-                        "country": "US",
-                        "state": "CA",
-                        "display_address": [
-                            "373 Columbus Ave",
-                            "San Francisco, CA 94133"
-                        ]
-                    },
-                    "phone": "+14154212337",
-                    "display_phone": "(415) 421-2337",
-                    "distance": 1465.2460213942109
-                },
-            ],
-            "total": 1,
-            "region": {
-                "center": {
-                    "longitude": -122.399972,
-                    "latitude": 37.786882
-                }
-            }
-        }),
-        ok: true
+        json: () => Promise.resolve(sampleYelpData)
     }),
 ) as jest.Mock;
 
@@ -143,9 +143,18 @@ describe("On vaild request to yelp api", () => {
                 lon: "-73.964741"
             }
         };
-        
+
+        (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+            Promise.resolve({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    businesses: sampleYelpData.businesses
+                })
+            } as unknown as Response)
+        );
+
         await getPubs(req, res);
         expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith({ error: "Failed to fetch bars missing lat" });
+        expect(res.json).toHaveBeenCalledWith({ businesses: sampleYelpData.businesses });
     });
 });

--- a/server/src/test/yelp.test.ts
+++ b/server/src/test/yelp.test.ts
@@ -1,0 +1,151 @@
+import { getPubs } from "../controllers/Yelp";
+
+/* Mock fetch function */
+global.fetch = jest.fn(() =>
+    Promise.resolve({
+        json: () => Promise.resolve({
+            "businesses": [
+                {
+                    "id": "FmGF1B-Rpsjq1f5b56qMwg",
+                    "alias": "molinari-delicatessen-san-francisco",
+                    "name": "Molinari Delicatessen",
+                    "image_url": "https://s3-media3.fl.yelpcdn.com/bphoto/CwWUZKM8T3QaSvvEMjI7pw/o.jpg",
+                    "is_closed": false,
+                    "url": "https://www.yelp.com/biz/molinari-delicatessen-san-francisco?adjust_creative=KmEoncUp5OnRvU5oNHoPyQ&utm_campaign=yelp_api_v3&utm_medium=api_v3_business_search&utm_source=KmEoncUp5OnRvU5oNHoPyQ",
+                    "review_count": 1379,
+                    "categories": [
+                        {
+                            "alias": "gourmet",
+                            "title": "Specialty Food"
+                        },
+                        {
+                            "alias": "delis",
+                            "title": "Delis"
+                        }
+                    ],
+                    "rating": 4.4,
+                    "coordinates": {
+                        "latitude": 37.79838,
+                        "longitude": -122.40782
+                    },
+                    "transactions": [
+                        "delivery",
+                        "pickup"
+                    ],
+                    "price": "$$",
+                    "location": {
+                        "address1": "373 Columbus Ave",
+                        "address2": "",
+                        "address3": "",
+                        "city": "San Francisco",
+                        "zip_code": "94133",
+                        "country": "US",
+                        "state": "CA",
+                        "display_address": [
+                            "373 Columbus Ave",
+                            "San Francisco, CA 94133"
+                        ]
+                    },
+                    "phone": "+14154212337",
+                    "display_phone": "(415) 421-2337",
+                    "distance": 1465.2460213942109
+                },
+            ],
+            "total": 1,
+            "region": {
+                "center": {
+                    "longitude": -122.399972,
+                    "latitude": 37.786882
+                }
+            }
+        }),
+        ok: true
+    }),
+) as jest.Mock;
+
+const res: any = {
+    status: jest.fn(() => res),
+    json: jest.fn(),
+};
+
+describe("On invalid request to yelp api", () => {
+    beforeEach((): void => {
+        jest.clearAllMocks();
+    });
+
+    it("should return error code 400 if lat is missing", async (): Promise<void> => {
+        const req: any = {
+            params: {
+                lat: null,
+                lon: "-34"
+            }
+        };
+
+        await getPubs(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "Failed to fetch bars missing lat" });
+    });
+
+    it("should return error code 400 if lon is missing", async (): Promise<void> => {
+        const req: any = {
+            params: {
+                lat: "91",
+                lon: null
+            }
+        };
+
+        await getPubs(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ error: "Failed to fetch bars missing lon" });
+    });
+
+    it("should return error code 401 if response is not okay", async (): Promise<void> => {
+        const req: any = {
+            params: {
+                lat: "40.768538",
+                lon: "-73.964741"
+            }
+        };
+        (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+            Promise.resolve({
+                ok: false,
+                json: jest.fn().mockResolvedValue({})
+            } as unknown as Response) // Convert to unknown first, then to Response
+        );
+        await getPubs(req, res);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith({ error: "Failed to fetch data from Yelp API" });
+    });
+
+    it("should return error code 500 if API is down", async (): Promise<void> => {
+        const req: any = {
+            params: {
+                lat: "40.768538",
+                lon: "-73.964741"
+            }
+        };
+        (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(Promise.reject("API is down"));
+        await getPubs(req, res);
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: "Failed to fetch pubs with unexpected error: API is down" });
+    });
+});
+
+describe("On vaild request to yelp api", () => {
+    beforeEach((): void => {
+        jest.clearAllMocks();
+    });
+
+    it("should return error code 200 if request was succesful", async (): Promise<void> => {
+        const req: any = {
+            params: {
+                lat: "40.768538",
+                lon: "-73.964741"
+            }
+        };
+        
+        await getPubs(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({ error: "Failed to fetch bars missing lat" });
+    });
+});


### PR DESCRIPTION
Initiated a server-side API connection call to the Yelp API that fetches local pubs close to the user. The server endpoint takes in the user's lat and lon and returns an array of pubs within the lat and lon provided.

This is a work around to the Yelp Fusion API blocking calls in the front-end with a cors cross-origin error